### PR TITLE
Added support for C++ projects.

### DIFF
--- a/etc/ld/lpc11u68_lib.ld
+++ b/etc/ld/lpc11u68_lib.ld
@@ -9,6 +9,7 @@
  */
 
  GROUP(
+ librdimon.a
  libgcc.a
  libc.a
  libm.a

--- a/etc/ld/lpc1769_lib.ld
+++ b/etc/ld/lpc1769_lib.ld
@@ -9,6 +9,7 @@
 
 
  GROUP(
+ librdimon.a
  libgcc.a
  libc.a
  libm.a

--- a/etc/ld/lpc4337_m0_lib.ld
+++ b/etc/ld/lpc4337_m0_lib.ld
@@ -8,6 +8,7 @@
  */
 
  GROUP(
+ librdimon.a
  libgcc.a
  libc.a
  libm.a

--- a/etc/ld/lpc4337_m4_lib.ld
+++ b/etc/ld/lpc4337_m4_lib.ld
@@ -9,6 +9,7 @@
 
 
  GROUP(
+ librdimon.a
  libgcc.a
  libc.a
  libm.a

--- a/etc/ld/lpc54102_m0_lib.ld
+++ b/etc/ld/lpc54102_m0_lib.ld
@@ -9,6 +9,7 @@
  */
 
  GROUP(
+ librdimon.a
  libgcc.a
  libc.a
  libm.a

--- a/etc/ld/lpc54102_m4_lib.ld
+++ b/etc/ld/lpc54102_m4_lib.ld
@@ -9,6 +9,7 @@
  */
 
  GROUP(
+ librdimon.a
  libgcc.a
  libc.a
  libm.a

--- a/etc/target/lpc11u68.mk
+++ b/etc/target/lpc11u68.mk
@@ -46,8 +46,13 @@ OBJ_PATH = $(OUT_PATH)/obj
 SYMBOLS += -DDEBUG -DCORE_M0PLUS -D__USE_LPCOPEN -D__CODE_RED \
            -D__MTB_BUFFER_SIZE=256 -D__USE_ROMDIVIDE
 
+XSYMBOLS += $(SYMBOLS) -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS
+
 # Compilation flags
 CFLAGS  := -Wall -ggdb3 -mcpu=cortex-m0 -mthumb -fdata-sections -ffunction-sections -fmessage-length=0 -fno-builtin
+
+# Compilation CXX flags
+CXXFLAGS := -Wall -ggdb3 -mcpu=cortex-m0 -mthumb -fdata-sections -ffunction-sections -fmessage-length=0 -fno-builtin
 
 # Linking flags
 LFLAGS  := -nostdlib -fno-builtin -mcpu=cortex-m0 -mthumb \

--- a/etc/target/lpc1769.mk
+++ b/etc/target/lpc1769.mk
@@ -44,9 +44,15 @@ CROSS_PREFIX ?= arm-none-eabi-
 # Defined symbols
 SYMBOLS := -DDEBUG -DCORE_M3 -D__USE_LPCOPEN -D__LPC17XX__ -D__CODE_RED
 
+XSYMBOLS += $(SYMBOLS) -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS
+
 # Compilation flags
 CFLAGS  := -Wall -ggdb3 -mcpu=cortex-m3 -mthumb -fdata-sections \
            -ffunction-sections -c
+
+# Compilation CXX flags
+CXXFLAGS := -Wall -ggdb3 -mcpu=cortex-m3 -mthumb -fdata-sections \
+	   -ffunction-sections -c
 
 # Linking flags
 LFLAGS  := -nostdlib -fno-builtin -mcpu=cortex-m3 -mthumb -Xlinker \

--- a/etc/target/lpc4337_m4.mk
+++ b/etc/target/lpc4337_m4.mk
@@ -47,9 +47,15 @@ SYMBOLS += -DDEBUG -DCORE_M4 -D__USE_LPCOPEN -D__LPC43XX__ -D__CODE_RED \
            -DLPC43_MULTICORE_M0APP -D__MULTICORE_MASTER \
 					 -D__MULTICORE_MASTER_SLAVE_M0APP
 
+XSYMBOLS += $(SYMBOLS) -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS
+
 # Compilation flags
 CFLAGS  := -Wall -ggdb3 -mcpu=cortex-m4 -mthumb -mfpu=fpv4-sp-d16 \
            -mfloat-abi=softfp -fdata-sections -ffunction-sections
+
+# Compliation CXX flags
+CXXFLAGS := -Wall -ggdb3 -mcpu=cortex-m4 -mthumb -mfpu=fpv4-sp-d16 \
+	   -mfloat-abi=softfp -fdata-sections -ffunction-sections
 
 # Linking flags
 LFLAGS  := -nostdlib -fno-builtin -mcpu=cortex-m4 -mthumb -mfpu=fpv4-sp-d16 \

--- a/etc/target/lpc54102_m0.mk
+++ b/etc/target/lpc54102_m0.mk
@@ -46,8 +46,13 @@ OBJ_PATH = $(OUT_PATH)/obj
 SYMBOLS += -DDEBUG -DCORE_M0PLUS -D__USE_LPCOPEN -D__LPC5410X__ -D__CODE_RED \
            -D__MULTICORE_M0SLAVE
 
+XSYMBOLS += $(SYMBOLS) -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS
+
 # Compilation flags
 CFLAGS  := -Wall -ggdb3 -mcpu=cortex-m0 -mthumb -fdata-sections -ffunction-sections -fmessage-length=0 -fno-builtin
+
+# Compilation CXX flags
+CXXFLAGS := -Wall -ggdb3 -mcpu=cortex-m0 -mthumb -fdata-sections -ffunction-sections -fmessage-length=0 -fno-builtin
 
 # Linking flags
 LFLAGS  := -nostdlib -fno-builtin -mcpu=cortex-m0 -mthumb \

--- a/etc/target/lpc54102_m4.mk
+++ b/etc/target/lpc54102_m4.mk
@@ -46,9 +46,15 @@ OBJ_PATH = $(OUT_PATH)/obj
 SYMBOLS += -DDEBUG -DCORE_M4 -D__USE_LPCOPEN -D__LPC5410X__ -D__CODE_RED \
            -D__MULTICORE_MASTER -D__MULTICORE_MASTER_SLAVE_M0SLAVE
 
+XSYMBOLS += $(SYMBOLS) -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS
+
 # Compilation flags
 CFLAGS  := -Wall -ggdb3 -mcpu=cortex-m4 -mthumb -mfpu=fpv4-sp-d16 \
            -mfloat-abi=softfp -fdata-sections -ffunction-sections
+
+# Compilation CXX flags
+CXXFLAGS := -Wall -ggdb3 -mcpu=cortex-m4 -mthumb -mfpu=fpv4-sp-d16 \
+	   -mfloat-abi=softfp -fdata-sections -ffunction-sections
 
 # Linking flags
 LFLAGS  := -nostdlib -fno-builtin -mcpu=cortex-m4 -mthumb -mfpu=fpv4-sp-d16 \

--- a/examples/blinky_cpp/Makefile
+++ b/examples/blinky_cpp/Makefile
@@ -2,6 +2,9 @@
 # All rights reserved.
 #
 # This file is part of Workspace.
+# Changes:
+# 2016-10-16: Iván Castellucci Vidal <ivanc.vidal@gmail.com>
+#    Added C++ sources to compilation process
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -28,49 +31,24 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-################################################################################
-#                Target Makefile for LPC4337 microcontroller                   #
-################################################################################
 
-# Target name
-TARGET_NAME := lpc4337_m0
+# application name
+PROJECT_NAME := $(notdir $(PROJECT))
 
-# Default cross-toolchain
-CROSS_PREFIX ?= arm-none-eabi-
+# Modules needed by the application
+PROJECT_MODULES := modules/$(TARGET)/base \
+                   modules/$(TARGET)/board \
+                   modules/$(TARGET)/chip
 
-# variables de rutas o carpetas
-OUT_PATH = out/$(TARGET_NAME)
-OBJ_PATH = $(OUT_PATH)/obj
+# source files folder
+PROJECT_SRC_FOLDERS := $(PROJECT)/src
 
-# Defined symbols
-SYMBOLS += -DDEBUG -DCORE_M0 -D__USE_LPCOPEN -D__LPC43XX__ -D__CODE_RED \
-           -D__MULTICORE_M0APP -DCORE_M0APP
+# header files folder
+PROJECT_INC_FOLDERS := $(PROJECT)/inc
 
-XSYMBOLS += $(SYMBOLS) -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS
+# source files
+PROJECT_C_FILES := $(wildcard $(PROJECT)/src/*.c)
 
-# Compilation flags
-CFLAGS  := -Wall -ggdb3 -mcpu=cortex-m0 -mthumb -fdata-sections -ffunction-sections
-
-# Compilation CXX flags
-CXXFLAGS := -Wall -ggdb3 -mcpu=cortex-m0 -mthumb -fdata-sections -ffunction-sections
-
-# Linking flags
-LFLAGS  := -nostdlib -fno-builtin -mcpu=cortex-m0 -mthumb \
-			  -Xlinker -Map=$(OUT_PATH)/$(PROJECT_NAME).map \
-			  -Wl,--gc-sections
-
-# Linker scripts
-LD_FILE := -Tetc/ld/lpc4337_m0_lib.ld -Tetc/ld/lpc4337_m0_mem.ld \
-           -Tetc/ld/lpc4337_m0.ld
-
-# OpenOCD configuration file
-CFG_FILE := etc/openocd/lpc4337.cfg
-
-# Flash base address for OpenOCD download rule
-BASE_ADDR := 0x1B000000
-
-# Download command
-DOWNLOAD_CMD := openocd -f $(CFG_FILE) -c "init" -c "halt 0" -c "flash write_image erase unlock $(OUT_PATH)/$(PROJECT_NAME).bin $(BASE_ADDR) bin" -c "reset run" -c "shutdown"
-
-# Erase command
-ERASE_CMD := openocd -f $(CFG_FILE) -c "init" -c "halt 0" -c "flash erase_sector 0 0 last" -c "exit"
+# Don't forget to add your CPP files to any C++ project
+PROJECT_CXX_FILES := $(wildcard $(PROJECT)/src/*.cpp)
+PROJECT_ASM_FILES := $(wildcard $(PROJECT)/src/*.S)

--- a/examples/blinky_cpp/inc/main.h
+++ b/examples/blinky_cpp/inc/main.h
@@ -30,31 +30,46 @@
  * POSSIBILITY OF SUCH DAMAGE.
  *
  */
- 
-#ifndef CIAAIO_H_
-#define CIAAIO_H_
 
-#include "chip.h"
+#ifndef _MAIN_H_
+#define _MAIN_H_
+
+/** \addtogroup blink Bare-metal blink example
+ ** @{ */
+
+/*==================[inclusions]=============================================*/
+
+/*==================[cplusplus]==============================================*/
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#define ciaaDigitalInputs() ((uint8_t)((Chip_GPIO_ReadValue(LPC_GPIO_PORT,3) & (0x0F<<11))>>7)|(Chip_GPIO_ReadValue(LPC_GPIO_PORT,2) & 0x0F))
+/*==================[macros]=================================================*/
 
-typedef struct
-{
-	int port;
-	int bit;
-}ciaaPin_t;
+/** delay in milliseconds */
+#define DELAY_MS 500
 
-void ciaaIOInit(void);
-uint32_t ciaaWriteOutput(uint32_t outputNumber, uint32_t value);
-uint32_t ciaaReadInput(uint32_t inputNumber);
-void ciaaToggleOutput(uint32_t outputNumber);
+/** led number to toggle */
+#define LED 0
+
+/*==================[typedef]================================================*/
+
+/*==================[external data declaration]==============================*/
+
+/*==================[external functions declaration]=========================*/
+
+/** @brief main function
+ * @return main function should never return
+ */
+int main(void);
+
+/*==================[cplusplus]==============================================*/
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* CIAAIO_H_ */
+/** @} doxygen end group definition */
+/*==================[end of file]============================================*/
+#endif /* #ifndef _MAIN_H_ */

--- a/examples/blinky_cpp/src/main.cpp
+++ b/examples/blinky_cpp/src/main.cpp
@@ -1,0 +1,109 @@
+/* Copyright 2016, Pablo Ridolfi
+ * All rights reserved.
+ *
+ * This file is part of Workspace.
+ *
+ * Changes:
+ * 2016-10-16: Iván Castellucci Vidal <ivanc.vidal@gmail.com>
+ *    Blinky as a C++ project
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+ 
+/** @brief This is a simple blink example.
+ */
+
+/** \addtogroup blink Bare-metal blink example
+ ** @{ */
+
+/*==================[inclusions]=============================================*/
+
+#include "main.h"
+#include "board.h"
+
+/*==================[macros and definitions]=================================*/
+
+/*==================[internal data declaration]==============================*/
+
+/*==================[internal functions declaration]=========================*/
+
+/** @brief hardware initialization function
+ *	@return none
+ */
+static void initHardware(void);
+
+/** @brief delay function
+ * @param t desired milliseconds to wait
+ */
+static void pausems(uint32_t t);
+
+/*==================[internal data definition]===============================*/
+
+/** @brief used for delay counter */
+static uint32_t pausems_count;
+
+/*==================[external data definition]===============================*/
+
+/*==================[internal functions definition]==========================*/
+
+static void initHardware(void)
+{
+	Board_Init();
+	SystemCoreClockUpdate();
+	SysTick_Config(SystemCoreClock / 1000);
+}
+
+static void pausems(uint32_t t)
+{
+	pausems_count = t;
+	while (pausems_count != 0) {
+		__WFI();
+	}
+}
+
+/*==================[external functions definition]==========================*/
+
+void SysTick_Handler(void)
+{
+	if(pausems_count > 0) pausems_count--;
+}
+
+int main(void)
+{
+	initHardware();
+
+	while (1)
+	{
+		Board_LED_Toggle(LED);
+		pausems(DELAY_MS);
+	}
+}
+
+/** @} doxygen end group definition */
+
+/*==================[end of file]============================================*/

--- a/modules/lpc4337_m4/ciaa/inc/ciaaAIN.h
+++ b/modules/lpc4337_m4/ciaa/inc/ciaaAIN.h
@@ -36,7 +36,15 @@
 
 #include "chip.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void ciaaAINInit(void);
 uint16_t ciaaAINRead(uint8_t input);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* CIAAAIN_H_ */

--- a/modules/lpc4337_m4/ciaa/inc/ciaaAOUT.h
+++ b/modules/lpc4337_m4/ciaa/inc/ciaaAOUT.h
@@ -36,7 +36,15 @@
 
 #include "chip.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void ciaaAOUTInit(void);
 void ciaaAOUTSet(float level);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* CIAAAOUT_H_ */

--- a/modules/lpc4337_m4/ciaa/inc/ciaaI2C.h
+++ b/modules/lpc4337_m4/ciaa/inc/ciaaI2C.h
@@ -36,8 +36,16 @@
 
 #include "chip.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void ciaaI2CInit(void);
 Status ciaaI2CWrite(uint8_t sl_addr, uint8_t * buffer, int len);
 Status ciaaI2CRead(uint8_t sl_addr, uint8_t * buffer, int len);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* CIAAI2C_H_ */

--- a/modules/lpc4337_m4/ciaa/inc/ciaaNVM.h
+++ b/modules/lpc4337_m4/ciaa/inc/ciaaNVM.h
@@ -37,10 +37,18 @@
 #include "chip.h"
 #include "ciaaI2C.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void mem48Read(uint8_t addr, void * buffer, int len);
 void mem48Write(uint8_t addr, void * buffer, int len);
 void memRead(uint16_t addr, void * buffer, int len);
 void memWrite(uint16_t addr, void * buffer, int len);
 void ciaaNVMInit(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* CIAANVM_H_ */

--- a/modules/lpc4337_m4/ciaa/inc/ciaaUART.h
+++ b/modules/lpc4337_m4/ciaa/inc/ciaaUART.h
@@ -37,6 +37,10 @@
 #include "chip.h"
 #include "string.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef enum _ciaaUarts_e
 {
 	CIAA_UART_485 = 0,
@@ -61,5 +65,9 @@ typedef struct _uartData
 void ciaaUARTInit(void);
 int uartSend(ciaaUART_e nUART, void * data, int datalen);
 int uartRecv(ciaaUART_e nUART, void * data, int datalen);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* CIAAUART_H_ */


### PR DESCRIPTION
Modified **main Makefile** to add support for C++ compilation. It has to include sources and make the final linking with a C++ capable compiler (g++).
Modified **etc/target/*.mk** to include CXXFLAGS.
Modified **etc/target/*_lib.ld** to include librdimon.a necessary for C++ symbols.
Modified **modules/lpc4337_m4/ciaa/inc/*.h** to handle both C and C++ projects.
Added an **example blinky** as a minimal C++ project. 

Any C++ project has to use a project Makefile aware of C++ files defining PROJECT_CXX_FILES as done in blinky_cpp 
